### PR TITLE
Tracking API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "require": {
         "php": "^5.5.9 || ^5.6 || ^7.0",
         "guzzlehttp/guzzle": "^6.0",
+        "openlss/lib-array2xml": "^0.5.1",
         "psr/log": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,28 +1,28 @@
 {
-  "name": "thejacer87/canadapost-api",
-  "type": "library",
-  "description": "PHP Canada Post API",
-  "keywords": ["canadapost", "api", "wrapper", "tracking", "shipping", "rate", "rating"],
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Jace Bennest",
-      "email": "jacebennest87@gmail.com"
-    }
-  ],
-  "require": {
-    "php": "^5.5.9 || ^5.6 || ^7.0",
-    "guzzlehttp/guzzle": "^6.0",
-    "psr/log": "^1.0"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^4.8 || ^5.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "CanadaPost\\": "src"
-    }
-  },
-  "minimum-stability": "dev",
-  "prefer-stable": true
+    "name": "thejacer87/canadapost-api",
+    "type": "library",
+    "description": "PHP Canada Post API",
+    "keywords": ["canadapost", "api", "wrapper", "tracking", "shipping", "rate", "rating"],
+    "license": "MIT",
+    "authors": [
+        {
+          "name": "Jace Bennest",
+          "email": "jacebennest87@gmail.com"
+        }
+    ],
+    "require": {
+        "php": "^5.5.9 || ^5.6 || ^7.0",
+        "guzzlehttp/guzzle": "^6.0",
+        "psr/log": "^1.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8 || ^5.0"
+    },
+    "autoload": {
+        "psr-4": {
+          "CanadaPost\\": "src"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/src/ClientBase.php
+++ b/src/ClientBase.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace CanadaPost;
+
+use CanadaPost\Exception\ClientException;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\ClientException as GuzzleClientException;
+use GuzzleHttp\Psr7\Response;
+use LSS\XML2Array;
+
+/**
+ * Provides a base class for Canada Post API clients.
+ */
+abstract class ClientBase
+{
+    const ENV_DEVELOPMENT = 'dev';
+    const ENV_PRODUCTION = 'prod';
+    const BASE_URL_DEVELOPMENT = 'https://ct.soa-gw.canadapost.ca';
+    const BASE_URL_PRODUCTION = 'https://soa-gw.canadapost.ca';
+
+    protected $config;
+    protected $baseUrl;
+    protected $username;
+    protected $password;
+
+    public function __construct(array $config = [])
+    {
+        // Default to development environment.
+        $this->config = array_merge(
+            ['env' => self::ENV_DEVELOPMENT],
+            $config
+        );
+        $this->setCredentials($config);
+        $this->baseUrl($this->config);
+    }
+
+    public function get($endpoint, array $headers = [])
+    {
+        $url = $this->baseUrl . '/' . $endpoint;
+
+        try {
+            $client = new GuzzleClient();
+            $options = [
+                'auth' => [$this->username, $this->password],
+                'headers' => $headers,
+            ];
+
+            // Enable debug option on development environment.
+            if ($this->config['env'] === self::ENV_DEVELOPMENT) {
+                $options['debug'] = TRUE;
+            }
+
+            $response = $client->request('GET', $url, $options);
+        }
+        catch (GuzzleClientException $exception) {
+            $response = $exception->getResponse();
+            $body = $this->parseResponse($response);
+
+            throw new ClientException(
+                $exception->getMessage(),
+                $this->parseResponse($response),
+                $exception->getRequest(),
+                $response,
+                $exception->getPrevious(),
+                $exception->getHandlerContext()
+            );
+        }
+
+        return $this->parseResponse($response);
+    }
+
+    protected function setCredentials(array $config = [])
+    {
+        if (!isset($config['username']) || !isset($config['password'])) {
+            $message = 'A username and a password are required for authenticated to the Canada Post API.';
+            throw new \InvalidArgumentException($message);
+        }
+
+        $this->username = $config['username'];
+        $this->password = $config['password'];
+    }
+
+    protected function baseUrl(array $config = [])
+    {
+        if (isset($this->baseUrl)) {
+            return $this->baseUrl;
+        }
+
+        if (isset($config['base_url'])) {
+            $this->baseUrl = $config['base_url'];
+            return $this->baseUrl;
+        }
+
+        switch ($config['env']) {
+            case self::ENV_DEVELOPMENT:
+                $this->baseUrl = self::BASE_URL_DEVELOPMENT;
+                break;
+
+            case self::ENV_PRODUCTION:
+                $this->baseUrl = self::BASE_URL_PRODUCTION;
+                break;
+
+            default:
+                $message = sprintf(
+                    'Unsupported environment "%s". Supported environments are "%s"',
+                    $config['env'],
+                    implode(', ', [self::ENV_DEVELOPMENT, self::ENV_PRODUCTION])
+                );
+                throw new \InvalidArgumentException($message);
+        }
+
+        return $this->baseUrl;
+    }
+
+    protected function parseResponse(Response $response)
+    {
+        $xml = new \DomDocument();
+        $xml->loadXML($response->getBody());
+
+        return XML2Array::createArray($xml->saveXML());
+    }
+}

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace CanadaPost\Exception;
+
+use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Exception when a client error is encountered (4xx codes).
+ *
+ * In addition to the request and the response, it makes available the parsed
+ * response body.
+ */
+class ClientException extends RequestException
+{
+    private $responseBody;
+
+    public function __construct(
+        $message,
+        $responseBody,
+        RequestInterface $request,
+        ResponseInterface $response = null,
+        \Exception $previous = null,
+        array $handlerContext = []
+    ) {
+        $this->responseBody = $responseBody;
+
+        parent::__construct(
+            $message,
+            $request,
+            $response,
+            $previous,
+            $handlerContext
+        );
+    }
+
+    public function getResponseBody()
+    {
+        return $this->responseBody;
+    }
+}

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace CanadaPost;
+
+class Tracking extends ClientBase
+{
+    public function getSummary($trackingPin)
+    {
+        $response = $this->get(
+            "vis/track/pin/{$trackingPin}/summary",
+            ['Accept' => 'application/vnd.cpc.track+xml']
+        );
+        return $response;
+    }
+}


### PR DESCRIPTION
Changes:

 - Formatted composer.json to use 4 spaces as is the standard in most cases.
 - Added a Guzzle-based base client to reuse for all APIs.
 - Tracking API client, currently only supports getting summary from tracking API.

Notes:

 - Using XML2Array for parsing responses. The same library contains an Array2XML class that should be used for building request bodies.
 - Following Psr coding standards instead of Drupal standards.
 - Missing docblocks and possibly some comments.